### PR TITLE
Wire green-story completion into the Ralph tick (fixes #13)

### DIFF
--- a/bin/ralph.sh
+++ b/bin/ralph.sh
@@ -12,13 +12,21 @@
 #   4. launches a fresh-context `claude` iteration per selected story and works
 #      as many eligible stories in sequence as the session budget allows, until
 #      no eligible work remains (no-work) or the loop halts (needs-human).
-#   5. when `claude` signals session-limit exhaustion, checkpoints the current
+#   5. when an iteration signals the story is green (the done-signal marker),
+#      promotes it: `ralph --complete-afk` (auto-merge → base) for a type:afk
+#      story, `ralph --complete-hil` (open PR → state:awaiting-bench) for HIL.
+#      Without this promotion the still-in-progress story would be re-selected
+#      forever (the engine is resume-first), so a green story must move off the
+#      backlog before the loop advances.
+#   6. when `claude` signals session-limit exhaustion, checkpoints the current
 #      story via a Handoff (`ralph --checkpoint`) and ends the tick cleanly.
 #
 # Ralph only ever modifies the superproject and never touches main. The heavy
-# lifting (TDD, gating, completion) lives in the `claude` iteration driven by
-# prompts/iterate.v1.md; this script is only the orchestration shell, kept thin
-# so it can be driven by tests against mocked `claude`/`gh` on PATH.
+# lifting (TDD, gating) lives in the `claude` iteration driven by
+# prompts/iterate.v1.md, which reports a green story via a done-signal marker;
+# this script is only the orchestration shell -- selecting, promoting green
+# stories, and checkpointing -- kept thin so it can be driven by tests against
+# mocked `claude`/`gh`/`git` on PATH.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -32,13 +40,20 @@ ITERATE_PROMPT="$SCRIPT_DIR/../prompts/iterate.v1.md"
 : "${RALPH_MAX_ITERATIONS:=25}"             # safety bound on stories per tick
 : "${RALPH_SESSION_LIMIT_EXIT:=91}"         # claude CLI exit signalling session-limit exhaustion
 : "${RALPH_SESSION_LIMIT_MARKER:=usage limit reached}"
+: "${RALPH_STORY_COMPLETE_MARKER:=RALPH-STORY-COMPLETE}"  # iteration's green/done-signal (prompts/iterate.v1.md)
 
 log() { printf 'ralph: %s\n' "$*"; }
 
-# Launch one fresh-context claude iteration for the selected story. Returns 0
-# normally, or RC_SESSION_LIMIT (10) when claude signalled session-limit
-# exhaustion (by exit code or output marker).
+# Launch one fresh-context claude iteration for the selected story. Returns:
+#   RC_SESSION_LIMIT (10) when claude signalled session-limit exhaustion (by exit
+#                         code or output marker) -- the story gets checkpointed;
+#   RC_STORY_COMPLETE (11) when the iteration emitted the done-signal marker,
+#                         meaning the gate is green and every acceptance criterion
+#                         is checked -- the story gets promoted;
+#   0                     otherwise (partial progress -- resume it next pass).
+# Session-limit takes priority: a truncated run never counts as complete.
 RC_SESSION_LIMIT=10
+RC_STORY_COMPLETE=11
 run_iteration() {
   local action="$1" issue="$2" out rc
   export RALPH_ITERATION_ACTION="$action" RALPH_ITERATION_ISSUE="$issue"
@@ -60,6 +75,9 @@ run_iteration() {
      || printf '%s' "$out" | grep -qiF "$RALPH_SESSION_LIMIT_MARKER"; then
     return "$RC_SESSION_LIMIT"
   fi
+  if printf '%s' "$out" | grep -qF "$RALPH_STORY_COMPLETE_MARKER"; then
+    return "$RC_STORY_COMPLETE"
+  fi
   return 0
 }
 
@@ -71,6 +89,28 @@ checkpoint_story() {
   gh issue view "$issue" \
      --json number,title,labels,body,comments,state \
    | "$RALPH_BIN" --checkpoint - "Session limit reached; resume next tick." "$RALPH_CONFIG"
+}
+
+# Promote a green story off the backlog. Reads the story's type:* label and
+# dispatches to the completion CLI that owns the label move / PR / merge:
+# type:afk -> --complete-afk (auto-merge into base, close), type:hil ->
+# --complete-hil (open PR, move to state:awaiting-bench). The completion tools
+# refuse to touch main and re-validate the type, so this stays a thin dispatch.
+# The story is fetched fresh so completion has the full record. Returns non-zero
+# on a git/gh/dispatch failure; the caller logs and moves on.
+complete_story() {
+  local issue="$1" story_json
+  story_json="$(gh issue view "$issue" --json number,title,labels,body,state)"
+  if grep -q '"type:afk"' <<<"$story_json"; then
+    log "green #$issue is type:afk; auto-merging (--complete-afk)"
+    "$RALPH_BIN" --complete-afk - "$RALPH_CONFIG" <<<"$story_json"
+  elif grep -q '"type:hil"' <<<"$story_json"; then
+    log "green #$issue is type:hil; opening PR (--complete-hil)"
+    "$RALPH_BIN" --complete-hil - "$RALPH_CONFIG" <<<"$story_json"
+  else
+    log "cannot promote #$issue: no type:afk/type:hil label"
+    return 2
+  fi
 }
 
 tick() {
@@ -105,13 +145,27 @@ tick() {
       resume|start)
         issue="${action_line##*#}"
         log "$kind #$issue"
-        if run_iteration "$kind" "$issue"; then
-          n=$(( n + 1 ))
-          continue
-        else
-          checkpoint_story "$issue"
-          return 0
-        fi
+        local rc=0
+        run_iteration "$kind" "$issue" || rc=$?
+        case "$rc" in
+          0)  # partial progress: resume the same story on the next pass
+            ;;
+          "$RC_STORY_COMPLETE")  # green: promote it off the backlog
+            complete_story "$issue" \
+              || log "promotion of #$issue failed (see above); leaving it in-progress"
+            ;;
+          "$RC_SESSION_LIMIT")
+            checkpoint_story "$issue"
+            return 0
+            ;;
+          *)
+            log "run_iteration returned unexpected code $rc for #$issue; checkpointing"
+            checkpoint_story "$issue"
+            return 0
+            ;;
+        esac
+        n=$(( n + 1 ))
+        continue
         ;;
       *)
         log "unrecognized action from --dry-run: $action_line"

--- a/prompts/iterate.v1.md
+++ b/prompts/iterate.v1.md
@@ -47,3 +47,24 @@ Commit all changes to the story branch with a clear message referencing the issu
 The base branch and `ai-utils` stay untouched. If context fills before the story is
 green, write a Handoff (issue comment + WIP commits) and terminate so the next
 iteration resumes with clean context.
+
+## 5. Signal done (green) — required
+
+The orchestrator (`bin/ralph.sh`) cannot see inside your session, so it needs an
+explicit machine-readable signal to know a story is finished and may be promoted
+(AFK auto-merge / HIL awaiting-bench). When — and **only** when — **both** hold:
+
+- `ralph --run-gating` passed (every gating step green, changes committed), and
+- **every** box in the story's `## Acceptance Criteria` is checked,
+
+print the done-signal marker on a line **by itself** as the final line of your
+output:
+
+```
+RALPH-STORY-COMPLETE
+```
+
+Do **not** print it for partial progress, a red gate, or a context-full Handoff —
+in those cases just commit/terminate and the orchestrator resumes the story next
+pass. You still never move labels, open the PR, or merge yourself (step above): the
+marker is the whole of your reporting; the completion stage owns the state change.

--- a/test/bats/orchestration.bats
+++ b/test/bats/orchestration.bats
@@ -35,6 +35,7 @@ EOF
 #!/usr/bin/env bash
 cat > /dev/null
 echo "claude action=${RALPH_ITERATION_ACTION:-} issue=${RALPH_ITERATION_ISSUE:-}" >> "$RALPH_LOG"
+[[ -n "${RALPH_CLAUDE_EMIT:-}" ]] && printf '%s\n' "$RALPH_CLAUDE_EMIT"
 exit "${RALPH_CLAUDE_EXIT:-0}"
 EOF
   cat >"$MB/git" <<'EOF'
@@ -97,4 +98,38 @@ story() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"halt"* ]]
   ! grep -q claude "$RALPH_LOG" 2>/dev/null
+}
+
+@test "a green AFK story is auto-merged and closed (not re-selected)" {
+  echo "[$(story 7 ready afk)]" > "$SP/ghq/0.json"
+  echo "[]" > "$SP/ghq/1.json"
+  story 7 ready afk > "$SP/ghq/story.json"
+  run bash -c "cd '$SP' && RALPH_CLAUDE_EMIT=RALPH-STORY-COMPLETE '$RALPH_SH'"
+  [ "$status" -eq 0 ]
+  [ "$(grep -c '^claude ' "$RALPH_LOG")" -eq 1 ]
+  grep -q 'gh pr merge' "$RALPH_LOG"
+  grep -q 'gh issue close 7' "$RALPH_LOG"
+}
+
+@test "a green HIL story opens a PR and moves to awaiting-bench" {
+  echo "[$(story 5 in-progress hil)]" > "$SP/ghq/0.json"
+  echo "[]" > "$SP/ghq/1.json"
+  story 5 in-progress hil > "$SP/ghq/story.json"
+  run bash -c "cd '$SP' && RALPH_CLAUDE_EMIT=RALPH-STORY-COMPLETE '$RALPH_SH'"
+  [ "$status" -eq 0 ]
+  grep -q 'gh pr create' "$RALPH_LOG"
+  grep -q 'state:awaiting-bench' "$RALPH_LOG"
+  ! grep -q 'gh pr merge' "$RALPH_LOG"
+  ! grep -q 'gh issue close' "$RALPH_LOG"
+}
+
+@test "a partial iteration (no done-signal) is not promoted" {
+  echo "[$(story 7 ready afk)]" > "$SP/ghq/0.json"
+  echo "[]" > "$SP/ghq/1.json"
+  story 7 ready afk > "$SP/ghq/story.json"
+  run bash -c "cd '$SP' && '$RALPH_SH'"
+  [ "$status" -eq 0 ]
+  grep -q '^claude ' "$RALPH_LOG"
+  ! grep -q 'gh pr merge' "$RALPH_LOG"
+  ! grep -q 'gh pr create' "$RALPH_LOG"
 }

--- a/test/unit/test_orchestrate.py
+++ b/test/unit/test_orchestrate.py
@@ -26,6 +26,7 @@ RALPH_SH = os.path.join(REPO_ROOT, "bin", "ralph.sh")
 FULL_CONFIG = os.path.join(REPO_ROOT, "test", "fixtures", "config", "valid", "full.yml")
 
 SESSION_LIMIT_EXIT = "91"
+STORY_COMPLETE_MARKER = "RALPH-STORY-COMPLETE"
 
 
 def story(number, state, type_="afk", prio=1, needs_human=False):
@@ -89,6 +90,7 @@ class TickHarness:
             #!/usr/bin/env bash
             cat > /dev/null
             echo "claude action=${RALPH_ITERATION_ACTION:-} issue=${RALPH_ITERATION_ISSUE:-}" >> "$RALPH_LOG"
+            [[ -n "${RALPH_CLAUDE_EMIT:-}" ]] && printf '%s\\n' "$RALPH_CLAUDE_EMIT"
             exit "${RALPH_CLAUDE_EXIT:-0}"
             """))
         _write_exec(os.path.join(mb, "git"), textwrap.dedent("""\
@@ -97,17 +99,19 @@ class TickHarness:
             exit 0
             """))
 
-    def env(self, claude_exit="0"):
+    def env(self, claude_exit="0", claude_emit=""):
         e = dict(os.environ)
         e["PATH"] = os.path.join(self.tmp, "mockbin") + os.pathsep + e["PATH"]
         e["RALPH_LOG"] = self.log
         e["RALPH_GH_QUEUE_DIR"] = self.queue
         e["RALPH_SESSION_LIMIT_EXIT"] = SESSION_LIMIT_EXIT
         e["RALPH_CLAUDE_EXIT"] = claude_exit
+        e["RALPH_CLAUDE_EMIT"] = claude_emit
         return e
 
-    def run(self, claude_exit="0"):
-        return subprocess.run([RALPH_SH], cwd=self.tmp, env=self.env(claude_exit),
+    def run(self, claude_exit="0", claude_emit=""):
+        return subprocess.run([RALPH_SH], cwd=self.tmp,
+                              env=self.env(claude_exit, claude_emit),
                               stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
 
     def log_lines(self):
@@ -194,6 +198,48 @@ class OrchestrationTest(unittest.TestCase):
         proc = h.run()
         self.assertEqual(proc.returncode, 0, proc.stdout)
         self.assertFalse(any("claude" in ln for ln in h.log_lines()), h.log_lines())
+
+    def test_green_afk_story_is_auto_merged_and_closed(self):
+        # AC: an iteration that emits the done-signal on a type:afk story is
+        # promoted via --complete-afk (auto-merge into base + close), not
+        # re-selected forever (the bug: green story never leaves the backlog).
+        h = self.harness()
+        h.set_backlogs([story(7, "ready", "afk")], [])  # then no-work -> stop
+        h.set_view_story(story(7, "ready", "afk"))
+        proc = h.run(claude_emit=STORY_COMPLETE_MARKER)
+        self.assertEqual(proc.returncode, 0, proc.stdout)
+        log = h.log_lines()
+        claude_calls = [ln for ln in log if ln.startswith("claude ")]
+        self.assertEqual(len(claude_calls), 1, log)  # promoted, not re-run
+        self.assertTrue(any("pr merge" in ln for ln in log), log)
+        self.assertTrue(any("issue close 7" in ln for ln in log), log)
+
+    def test_green_hil_story_opens_pr_to_awaiting_bench(self):
+        # AC: a green type:hil story is promoted via --complete-hil (open PR +
+        # move to state:awaiting-bench); it is never merged or closed.
+        h = self.harness()
+        h.set_backlogs([story(5, "in-progress", "hil")], [])
+        h.set_view_story(story(5, "in-progress", "hil"))
+        proc = h.run(claude_emit=STORY_COMPLETE_MARKER)
+        self.assertEqual(proc.returncode, 0, proc.stdout)
+        log = h.log_lines()
+        self.assertTrue(any("pr create" in ln for ln in log), log)
+        self.assertTrue(any("state:awaiting-bench" in ln for ln in log), log)
+        self.assertFalse(any("pr merge" in ln for ln in log), log)
+        self.assertFalse(any("issue close" in ln for ln in log), log)
+
+    def test_partial_iteration_is_not_promoted(self):
+        # AC: an iteration WITHOUT the done-signal made only partial progress and
+        # must not be promoted (no completion CLI runs); the story is left for a
+        # later pass. Here the backlog empties out so the tick then stops.
+        h = self.harness()
+        h.set_backlogs([story(7, "ready", "afk")], [])
+        h.set_view_story(story(7, "ready", "afk"))
+        proc = h.run()  # no marker emitted
+        self.assertEqual(proc.returncode, 0, proc.stdout)
+        log = h.log_lines()
+        self.assertTrue(any(ln.startswith("claude ") for ln in log), log)
+        self.assertFalse(any("pr merge" in ln or "pr create" in ln for ln in log), log)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The tick loop drove a story to a green gate but never promoted it: it never called `ralph --complete-hil`/`--complete-afk`. Because the selection engine is resume-first, the still-in-progress green story was re-selected every pass and re-verified until the session limit tripped — no PR, no state:awaiting-bench, no auto-merge.

Two coupled gaps, both closed here:

- No done-signal from the iteration. `run_iteration` returned 0 for both "finished green" and "partial progress". Add a machine-readable marker (RALPH-STORY-COMPLETE, env-overridable) the iteration emits only when gating is green AND every acceptance box is checked; run_iteration now returns RC_STORY_COMPLETE (11), RC_SESSION_LIMIT (10), or 0 (partial), with session-limit taking priority so a truncated run never counts done.

- No completion wiring. tick() now routes on the return code: promote a green story via new complete_story() (reads the type: label and dispatches to --complete-afk / --complete-hil, which own the label move / PR / merge and refuse to touch main), checkpoint on session limit, or loop back on partial progress.

Document the done-signal convention in prompts/iterate.v1.md. Add orchestration tests (executed test_orchestrate.py + parity bats) covering green AFK auto-merge+close, green HIL PR→awaiting-bench, and that a partial iteration is not promoted.