### PR TITLE
fix: Add ralph --init bootstrap, wire the start transition, make prio optional

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,9 @@ not HITL) and `docs/adr/0001–0005`.
   objects or plain strings) and is the canonical story-format checker the selection engine
   builds on. Fixtures for story-shaped logic live under `test/fixtures/stories/`.
 - `lib/ralph_select.py` is the pure selection engine (`normalize` → `select_next` →
-  `Action`). It reuses `ralph_story`'s field extraction but owns ordering (prio ascending,
-  ties by lowest issue number, FIFO) and dependency satisfaction. The scan must request the
+  `Action`). It reuses `ralph_story`'s field extraction but owns ordering (optional prio
+  ascending — absent prio sorts last — ties by lowest issue number, FIFO) and dependency
+  satisfaction. The scan must request the
   gh `state` field: a `Depends on:` edge is satisfied only when the referenced issue is
   closed (an AFK dep once merged, a HIL dep once bench-verified — both surface as closed).
   Don't confuse gh's `state` (OPEN/CLOSED) with the `state:` label (ready/in-progress/…).
@@ -101,21 +102,33 @@ not HITL) and `docs/adr/0001–0005`.
   `prompts/memory.v1.md` (drift-guarded). NOTE: the reference snarktank loop's `progress.txt`
   is the build harness in `ralph/`, which is deliberately separate from the tool being built —
   the tool ships no progress.txt.
-- `bin/ralph.sh` is the unattended **tick** (US-011, ADR-0002/0004/Tick): pure orchestration,
-  no logic — the TDD/gating/completion all happen inside the `claude` iteration it launches
-  (driven by `prompts/iterate.v1.md`). Order: (1) `flock -n` a lockfile under `.git/`
-  (`RALPH_LOCK_DIR`, default `.git`) so only one tick per superproject runs — an overlapping
-  tick logs "already running" and exits 0; (2) `ralph --check-config` (fail loud, ADR-0001);
-  (3) loop calling `ralph --dry-run` (which is already resume-first) and launching one
-  fresh-context `claude --print` iteration per selected story, working stories in sequence
-  until `--dry-run` returns `no-work`/`halt`. Session-limit exhaustion is detected from the
-  claude exit code (`RALPH_SESSION_LIMIT_EXIT`) or an output marker; on it the tick fetches
-  the story via `gh issue view` and checkpoints through `ralph --checkpoint -` (Handoff), then
-  ends cleanly. Every knob is an env var so tests/superprojects override without editing the
-  script. Covered by `test/bats/orchestration.bats` (run by `test/run.sh` when bats is present)
-  AND `test/unit/test_orchestrate.py` (the executed gate here — bats is not installed — driving
-  the script against mock `claude`/`gh`/`git` on PATH via `$RALPH_LOG` + a stateful `gh issue
-  list` queue that pops one backlog fixture per call to simulate stories completing).
+- `bin/ralph.sh` is the unattended **tick** (US-011, ADR-0002/0004/Tick): thin orchestration —
+  the TDD/gating happen inside the `claude` iteration it launches (driven by
+  `prompts/iterate.v1.md`), but the tick owns the state transitions around it. Order: (1)
+  `flock -n` a lockfile under `.git/` (`RALPH_LOCK_DIR`, default `.git`) so only one tick per
+  superproject runs — an overlapping tick logs "already running" and exits 0; (2)
+  `ralph --check-config` (fail loud, ADR-0001); (3) loop calling `ralph --dry-run` (already
+  resume-first) and launching one fresh-context `claude --print` iteration per selected story,
+  working stories in sequence until `--dry-run` returns `no-work`/`halt`. A `start` action
+  first moves the story `state:ready`→`state:in-progress` (`begin_story`, the state-machine
+  `start` edge every later stage assumes); `resume` is left as-is. `run_iteration` returns
+  three outcomes: session-limit (checkpoint via `ralph --checkpoint -` and end), the story
+  done-signal marker `RALPH_STORY_COMPLETE_MARKER` (**promote**: `complete_story` reads the
+  `type:` label and dispatches to `ralph --complete-afk`/`--complete-hil`), or partial progress
+  (loop back; the now-in-progress story is `resume`d next pass). Every knob is an env var so
+  tests/superprojects override without editing the script. Covered by
+  `test/bats/orchestration.bats` (run by `test/run.sh` when bats is present) AND
+  `test/unit/test_orchestrate.py` (the executed gate here — bats is not installed — driving the
+  script against mock `claude`/`gh`/`git` on PATH via `$RALPH_LOG` + a stateful `gh issue list`
+  queue that pops one backlog fixture per call to simulate stories completing).
+- `lib/ralph_init.py` is the one-shot bootstrap seam (`ralph --init`): same pure-`Plan`/
+  `run_plan`/CLI shape as the completion stages. `init_plan(base, base_exists, default_branch,
+  prio_max)` returns the ordered gh/git commands to `gh label create --force` the canonical
+  vocabulary (`FIXED_LABELS` — the exact `state:`/`type:`/`needs-human`/`ready-for-human`
+  labels `ralph_story`/`ralph_select` consume — plus a `prio:0..N` starter range) and, when
+  `base` is missing, create it off the default branch (refusing to fabricate `main`, ADR-0001).
+  The CLI detects live state (`_remote_has_branch`, `_default_branch`) then runs the plan.
+  Idempotent by construction (`--force`, skip-if-present). Covered by `test/unit/test_init.py`.
 - `scheduler/` ships the sample schedulers (US-012, ADR-0001): systemd `ralph.service`
   (`Type=oneshot`, `ExecStart=.../bin/ralph.sh`) + `ralph.timer` (`OnCalendar=*-*-* 00/5:00:00`,
   i.e. every 5h) and a `ralph.cron` one-liner (`0 */5 * * *`). Both just fire the flock-guarded

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ configurable**:
 
 - **State** (exactly one): `state:ready` → `state:in-progress` → `state:awaiting-bench` → *closed* (= Done).
 - **Type** (exactly one): `type:afk` or `type:hil`.
-- **Priority** (exactly one): `prio:N`, lower = higher priority. Ties break by lowest issue number (FIFO).
+- **Priority** (optional, at most one): `prio:N`, lower = higher priority. A story with no `prio:N` sorts as lowest priority; ties (and prio-less stories) break by lowest issue number (FIFO). Add `prio:N` only to jump the queue.
 - **Dependencies**: a `Depends on: #12, #34` line in the body. A story is
   ineligible until every dependency is *Passing* (closed) — for a HIL dependency
   that means bench-verified.
@@ -130,21 +130,29 @@ scheduler (every ~5h)
    ai-utils/bin/ralph --check-config
    ```
 
-4. **Author some stories** as GitHub issues in the canonical shape (see
+4. **Initialize the repo** — create the canonical labels and the base branch
+   (idempotent; safe to re-run). Do this once per superproject, before authoring
+   stories, or `gh issue edit --add-label state:…` will fail with `not found`:
+
+   ```sh
+   ai-utils/bin/ralph --init
+   ```
+
+5. **Author some stories** as GitHub issues in the canonical shape (see
    [Authoring the backlog](#authoring-the-backlog)), and lint them:
 
    ```sh
    gh issue view 42 --json number,title,labels,body | ai-utils/bin/ralph --lint-story -
    ```
 
-5. **Dry-run the selector** to see what Ralph would pick up next — this changes
+6. **Dry-run the selector** to see what Ralph would pick up next — this changes
    nothing:
 
    ```sh
    ai-utils/bin/ralph --dry-run
    ```
 
-6. **Run a tick** manually to try the full loop, or wire `ai-utils/bin/ralph.sh`
+7. **Run a tick** manually to try the full loop, or wire `ai-utils/bin/ralph.sh`
    into a scheduler (e.g. cron every 5 hours) for unattended operation:
 
    ```sh
@@ -252,7 +260,7 @@ the `to-issues` workflow to emit exactly this shape — use it when planning wor
 
 Every story needs:
 
-- exactly one `state:`, one `type:` (except Blockers), and one `prio:` label,
+- exactly one `state:` and one `type:` label (except Blockers), and at most one (optional) `prio:` label,
 - a `## Acceptance Criteria` heading with at least one `- [ ]` checklist item,
 - a `Depends on:` line (`None`, or `#`-prefixed issue numbers),
 - for HIL stories, an additional `## Bench Test Procedure` section.
@@ -293,6 +301,7 @@ orchestrator (`bin/ralph.sh`) and the agent stitch them together. Run
 
 | Command | What it does |
 | --- | --- |
+| `ralph --init [CONFIG]` | Bootstrap the superproject: idempotently create the canonical labels and, if missing, the base branch (off the default branch). Run once per repo before authoring stories. |
 | `ralph --check-config [PATH]` | Validate `.ralph.yml` (default `./.ralph.yml`) against the schema. |
 | `ralph --lint-story PATH` | Validate a story issue (gh JSON shape; `-` for stdin) against the canonical format. |
 | `ralph --dry-run [PATH]` | Scan the backlog and print the next action (`resume #N` / `start #N` / `no-work` / `halt`), changing nothing. Reads a JSON backlog from `PATH`, or scans live via `gh`. |

--- a/bin/ralph
+++ b/bin/ralph
@@ -2,6 +2,7 @@
 # ralph - the Ralph Loop CLI (shipped from ai-utils, invoked from a superproject).
 #
 # Subcommands are added as stories land. Today:
+#   ralph --init [CONFIG]         Bootstrap the superproject: create the canonical labels + base branch.
 #   ralph --check-config [PATH]   Validate .ralph.yml (default ./.ralph.yml) and exit.
 #   ralph --lint-story PATH       Validate a canonical Ralph story issue (JSON, or - for stdin).
 #   ralph --dry-run [PATH]        Scan the backlog and print the next action, changing nothing.
@@ -21,7 +22,8 @@ RALPH_HOME="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 usage() {
   cat <<'EOF'
-usage: ralph --check-config [PATH]
+usage: ralph --init [CONFIG]
+       ralph --check-config [PATH]
        ralph --lint-story PATH
        ralph --dry-run [PATH]
        ralph --branch-name STORY [CONFIG]
@@ -35,6 +37,13 @@ usage: ralph --check-config [PATH]
        ralph --read-learnings DIR [ROOT]
        ralph --learn-target PATH [ROOT]
 
+  --init [CONFIG]         Bootstrap the superproject for the Ralph Loop:
+                          idempotently create the canonical state:/type:/prio:/
+                          needs-human/ready-for-human GitHub labels and, if the
+                          configured base branch is missing, create it off the
+                          repo's default branch. Reads the base from CONFIG
+                          (default .ralph.yml). Safe to re-run. Exits 0 on
+                          success, 1 on a git/gh failure, 2 on bad config.
   --check-config [PATH]   Validate a .ralph.yml config against the shipped
                           JSON-schema (default: ./.ralph.yml). Exits 0 on a
                           valid config, non-zero (reporting the offending
@@ -96,6 +105,10 @@ EOF
 
 main() {
   case "${1:-}" in
+    --init)
+      shift
+      exec python3 "$RALPH_HOME/lib/ralph_init.py" init "$@"
+      ;;
     --check-config)
       local config="${2:-.ralph.yml}"
       exec python3 "$RALPH_HOME/lib/ralph_config.py" "$config"

--- a/bin/ralph.sh
+++ b/bin/ralph.sh
@@ -91,6 +91,21 @@ checkpoint_story() {
    | "$RALPH_BIN" --checkpoint - "Session limit reached; resume next tick." "$RALPH_CONFIG"
 }
 
+# Move a freshly-selected story from state:ready to state:in-progress before its
+# first iteration. This is the `start` edge of the state machine that the rest of
+# the loop assumes exists: a mid-iteration checkpoint then resumes it (resume-first
+# needs state:in-progress), a partial pass is re-selected as `resume` not `start`,
+# and HIL/AFK completion's `--remove-label state:in-progress` has a label to move.
+# Best-effort: a failure here almost always means the labels were never created,
+# so point at `ralph --init` and continue (the iteration can still do work).
+begin_story() {
+  local issue="$1"
+  log "moving #$issue to state:in-progress"
+  gh issue edit "$issue" \
+     --add-label state:in-progress --remove-label state:ready \
+   || log "could not label #$issue state:in-progress (are the Ralph labels created? run 'ralph --init'); continuing"
+}
+
 # Promote a green story off the backlog. Reads the story's type:* label and
 # dispatches to the completion CLI that owns the label move / PR / merge:
 # type:afk -> --complete-afk (auto-merge into base, close), type:hil ->
@@ -145,6 +160,12 @@ tick() {
       resume|start)
         issue="${action_line##*#}"
         log "$kind #$issue"
+        # `start` moves a state:ready story into state:in-progress up front, so a
+        # checkpoint/partial pass/completion all see the expected state. `resume`
+        # is already in-progress (a prior tick moved it), so it is left alone.
+        if [[ "$kind" == "start" ]]; then
+          begin_story "$issue"
+        fi
         local rc=0
         run_iteration "$kind" "$issue" || rc=$?
         case "$rc" in

--- a/docs/adr/0002-labels-as-backlog-source-of-truth.md
+++ b/docs/adr/0002-labels-as-backlog-source-of-truth.md
@@ -5,7 +5,9 @@ Ralph reads the superproject's backlog from GitHub Issues. The authoritative, ma
 Encoding:
 - **State** (mutually exclusive): `state:ready` → `state:in-progress` → `state:awaiting-bench` → closed (= Done).
 - **Type**: `type:afk` / `type:hil`.
-- **Priority**: explicit `prio:N` labels (lower = higher priority). Not issue-number ordering, so stories can be reprioritized without renumbering. Ties within a `prio:N` break by **lowest issue number (pure FIFO)** — deterministic and predictable, deliberately avoiding fan-out/AFK-first heuristics so Ralph never second-guesses the encoded priority.
+- **Priority**: an **optional** `prio:N` label (lower = higher priority), at most one per story. Not issue-number ordering, so stories can be reprioritized without renumbering. Ties within a `prio:N` break by **lowest issue number (pure FIFO)** — deterministic and predictable, deliberately avoiding fan-out/AFK-first heuristics so Ralph never second-guesses the encoded priority. A story that carries **no** `prio:N` sorts as lowest priority (behind every prioritized story) and falls back to pure FIFO among other prio-less stories — so priority is a deliberate override you add only when a story must jump the queue, not a tax on every issue.
+
+  > **Amendment (was: "exactly one `prio:N` required").** Priority was originally mandatory. It is now optional: the common case is FIFO-by-issue-number, and forcing an arbitrary `prio:N` on every story added noise without meaning. The ordering key is unchanged (`(prio, issue#)` ascending, `prio` absent = `+inf`); only the requirement was dropped.
 - **Dependencies**: a `Depends on: #12, #34` line in the body; a story is ineligible until every referenced issue is Passing (closed). A HIL dependency counts as satisfied only once bench-verified.
 - **Acceptance criteria**: a `## Acceptance Criteria` checklist. HIL stories also carry a `## Bench Test Procedure` section.
 

--- a/lib/ralph_init.py
+++ b/lib/ralph_init.py
@@ -1,0 +1,197 @@
+"""One-shot superproject bootstrap for the Ralph Loop (`ralph --init`).
+
+Ralph reads and writes the backlog through GitHub labels (ADR-0002), and it
+branches every story off the configured `base`. A fresh superproject has neither:
+`gh issue edit --add-label state:in-progress` fails with `'state:...' not found`,
+and an iteration cannot branch off a `base` that does not exist. `ralph --init`
+creates both, idempotently, so onboarding is one command instead of a pile of
+manual `gh label create` calls.
+
+The deterministic seam mirrors the completion stages: `init_plan` is a pure
+function that returns the ordered git/gh commands (as argv lists) without running
+anything, so the canonical label set and the base-branch policy are unit-testable.
+`run_plan` executes a plan fail-fast; the CLI wrapper (`ralph --init`) detects the
+live repo state (does `base` exist? what is the default branch?), builds the plan,
+and prints + sets exit codes.
+
+The label vocabulary is canonical and NOT configurable (ADR-0002): it is exactly
+what `ralph_story`/`ralph_select` consume. `prio:N` is optional per story, so init
+seeds a small starter range (prio:0..prio:5); authors add higher ones ad hoc.
+"""
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import ralph_config  # noqa: E402
+
+PROTECTED_BRANCH = "main"
+DEFAULT_PRIO_MAX = 5
+
+# The canonical fixed vocabulary (name, color hex without '#', description).
+# Mirrors ralph_story.STATES/TYPES/BLOCKER_LABEL and ralph_select.NEEDS_HUMAN.
+FIXED_LABELS = [
+    ("state:ready", "0e8a16", "Ready for Ralph to start"),
+    ("state:in-progress", "fbca04", "Ralph is actively working this story"),
+    ("state:awaiting-bench", "d93f0b",
+     "HIL story: PR open, awaiting human bench verification"),
+    ("state:blocked", "b60205",
+     "Blocked: too many failed Attempts or an unmet dependency"),
+    ("type:afk", "1d76db",
+     "Away-from-keyboard: verifiable by CI alone; Ralph auto-merges when green"),
+    ("type:hil", "5319e7",
+     "Human-in-the-loop: needs physical bench verification"),
+    ("needs-human", "e11d21",
+     "Circuit breaker tripped: the loop is halted, awaiting a human"),
+    ("ready-for-human", "0052cc",
+     "Design-decision Blocker: kept out of state:ready until a human resolves it"),
+]
+
+PRIO_COLOR = "c5def5"
+
+
+def prio_labels(prio_max=DEFAULT_PRIO_MAX):
+    """The starter prio:0..prio:N labels (optional per story; lower = higher)."""
+    return [("prio:%d" % n, PRIO_COLOR,
+             "Priority %d (lower = higher priority; optional)" % n)
+            for n in range(prio_max + 1)]
+
+
+def canonical_labels(prio_max=DEFAULT_PRIO_MAX):
+    return FIXED_LABELS + prio_labels(prio_max)
+
+
+def _label_command(name, color, description):
+    # --force makes it idempotent: create the label, or update its color and
+    # description if it already exists. Safe to re-run on an initialized repo.
+    return ["gh", "label", "create", name,
+            "--color", color, "--description", description, "--force"]
+
+
+def _base_commands(base, base_exists, default_branch):
+    """Commands to ensure `base` exists on origin, or [] if nothing to do.
+
+    Refuses to fabricate `main` (Ralph never touches main, ADR-0001) and never
+    creates a base that already exists. When missing, `base` is branched off the
+    repo's default branch on origin without disturbing the working tree.
+    """
+    if not base or base_exists:
+        return []
+    if base.strip().lower() == PROTECTED_BRANCH:
+        return []
+    return [
+        ["git", "fetch", "origin", "--quiet"],
+        ["git", "push", "origin",
+         "origin/%s:refs/heads/%s" % (default_branch, base)],
+    ]
+
+
+def init_plan(base=None, base_exists=True, default_branch=PROTECTED_BRANCH,
+              prio_max=DEFAULT_PRIO_MAX):
+    """Build the ordered command plan to bootstrap a superproject.
+
+    Pure: computes commands, runs nothing. Creates (or force-updates) the whole
+    canonical label vocabulary, then, if `base` is missing, creates it off the
+    default branch. Idempotent by construction.
+    """
+    commands = [_label_command(*lbl) for lbl in canonical_labels(prio_max)]
+    commands += _base_commands(base, base_exists, default_branch)
+    return commands
+
+
+class CommandResult:
+    def __init__(self, args, returncode, output):
+        self.args = args
+        self.returncode = returncode
+        self.output = output
+        self.ok = returncode == 0
+
+
+class RunResult:
+    def __init__(self, steps):
+        self.steps = steps
+        self.failed = next((s for s in steps if not s.ok), None)
+        self.ok = self.failed is None
+
+
+def run_plan(commands, cwd=None):
+    """Execute plan commands (argv lists) in order, stopping at the first failure.
+
+    Each command's combined stdout+stderr is captured (low-verbosity: the CLI
+    surfaces output only for a failing command). Returns a RunResult.
+    """
+    results = []
+    for args in commands:
+        proc = subprocess.run(
+            args, cwd=cwd,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+        )
+        results.append(CommandResult(args, proc.returncode, proc.stdout))
+        if proc.returncode != 0:
+            break
+    return RunResult(results)
+
+
+def _remote_has_branch(base, cwd=None):
+    proc = subprocess.run(
+        ["git", "ls-remote", "--heads", "origin", base],
+        cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    return proc.returncode == 0 and bool(proc.stdout.strip())
+
+
+def _default_branch(cwd=None):
+    proc = subprocess.run(
+        ["gh", "repo", "view", "--json", "defaultBranchRef",
+         "--jq", ".defaultBranchRef.name"],
+        cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    name = proc.stdout.strip() if proc.returncode == 0 else ""
+    return name or PROTECTED_BRANCH
+
+
+def _cmd_init(rest):
+    config_path = rest[0] if rest and rest[0] else ".ralph.yml"
+
+    result = ralph_config.load_and_validate(config_path)
+    if not result.ok:
+        sys.stderr.write("INVALID CONFIG: %s\n" % config_path)
+        for err in result.errors:
+            sys.stderr.write("  - %s\n" % err)
+        sys.stderr.write("ralph --init needs a valid .ralph.yml (it reads the base branch)\n")
+        return 2
+    base = result.config["branching"]["base"]
+
+    cwd = os.getcwd()
+    base_exists = _remote_has_branch(base, cwd=cwd)
+    default_branch = _default_branch(cwd=cwd)
+
+    plan = init_plan(base=base, base_exists=base_exists,
+                     default_branch=default_branch)
+    run = run_plan(plan, cwd=cwd)
+    if run.ok:
+        n_labels = len(canonical_labels())
+        if not base or base.strip().lower() == PROTECTED_BRANCH or base_exists:
+            base_note = "base branch %r already present" % base
+        else:
+            base_note = "created base branch %r off %r" % (base, default_branch)
+        print("OK: initialized %d labels; %s" % (n_labels, base_note))
+        return 0
+    sys.stderr.write("FAILED: init (exit %d): %s\n"
+                     % (run.failed.returncode, " ".join(run.failed.args)))
+    if run.failed.output.strip():
+        sys.stderr.write(run.failed.output.rstrip() + "\n")
+    return 1
+
+
+def main(argv):
+    if not argv:
+        sys.stderr.write("usage: ralph_init.py init [config]\n")
+        return 2
+    mode, rest = argv[0], argv[1:]
+    if mode == "init":
+        return _cmd_init(rest)
+    sys.stderr.write("ralph_init.py: unknown mode: %s\n" % mode)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/lib/ralph_select.py
+++ b/lib/ralph_select.py
@@ -11,6 +11,8 @@ Rules (ADR-0002, CONTEXT.md):
   - Resume-first: any state:in-progress story is chosen before any state:ready
     scan (a prior iteration checkpointed it via Handoff).
   - Ordering: prio:N ascending, ties broken by lowest issue number (pure FIFO).
+    prio is optional (ADR-0002): a story with no prio:N sorts as lowest priority
+    (prio = +inf), i.e. it falls back to pure FIFO behind every prioritized story.
   - state:blocked stories and design-decision Blockers (ready-for-human, kept
     out of state:ready) are skipped.
   - Dependencies: a `Depends on: #N` edge is satisfied only when #N is Passing,

--- a/lib/ralph_story.py
+++ b/lib/ralph_story.py
@@ -78,8 +78,14 @@ def validate_story(story):
     is_blocker = BLOCKER_LABEL in names
 
     # --- rules common to every story --------------------------------------
-    if len(prios) != 1 or not prios[0].isdigit():
-        errors.append("labels: exactly one prio:N label is required (lower = higher priority)")
+    # prio is optional: a story may carry zero or one prio:N label. With none,
+    # prio is None and the selection engine sorts it as lowest priority -- it
+    # falls back to FIFO by issue number. Authors add prio:N only to jump the
+    # queue (ADR-0002). More than one, or a non-numeric prio:, is still an error.
+    if len(prios) > 1:
+        errors.append("labels: at most one prio:N label is allowed (lower = higher priority)")
+    elif prios and not prios[0].isdigit():
+        errors.append("labels: a prio: label must be numeric (prio:N, lower = higher priority)")
     prio = int(prios[0]) if len(prios) == 1 and prios[0].isdigit() else None
 
     if "HITL" in body or "HITL" in (story.get("title") or ""):

--- a/skills/ralph-story/SKILL.md
+++ b/skills/ralph-story/SKILL.md
@@ -31,9 +31,10 @@ mandated and not overridable (it is fixed in the config schema, ADR-0002).
     refactors, build config). Passing as soon as CI is green.
   - `type:hil` — acceptance requires human verification on the physical bench (GPIO, timing,
     sensors, actuators). Passing only when CI is green **and** a human bench-verifies it.
-- **Priority** (exactly one): `prio:N`, lower = higher priority. Ties break by lowest issue
+- **Priority** (optional, at most one): `prio:N`, lower = higher priority. A story with no
+  `prio:N` sorts as lowest priority; ties (and prio-less stories) break by lowest issue
   number (FIFO). Priority is explicit labels, not issue-number ordering, so stories can be
-  reprioritized without renumbering.
+  reprioritized without renumbering — add `prio:N` only to jump the queue.
 
 ### Body
 
@@ -89,7 +90,7 @@ Depends on: #12, #34      ← or `Depends on: None`
 
 Rules the template encodes (verify with `ralph --lint-story`, below):
 
-- Exactly one `state:`, one `type:` (except Blockers), and one `prio:` label.
+- Exactly one `state:` and one `type:` label (except Blockers); at most one (optional) `prio:` label.
 - A `## Acceptance Criteria` heading with at least one `- [ ]` checklist item.
 - HIL stories additionally carry a `## Bench Test Procedure` section.
 - A `Depends on:` line (either `None` or `#`-prefixed issue numbers). A story is ineligible

--- a/test/bats/orchestration.bats
+++ b/test/bats/orchestration.bats
@@ -100,6 +100,22 @@ story() {
   ! grep -q claude "$RALPH_LOG" 2>/dev/null
 }
 
+@test "start moves a ready story to state:in-progress before iterating" {
+  echo "[$(story 7 ready afk)]" > "$SP/ghq/0.json"
+  echo "[]" > "$SP/ghq/1.json"
+  run bash -c "cd '$SP' && '$RALPH_SH'"
+  [ "$status" -eq 0 ]
+  grep -q 'gh issue edit 7 --add-label state:in-progress --remove-label state:ready' "$RALPH_LOG"
+}
+
+@test "resume does not re-label an already in-progress story" {
+  echo "[$(story 5 in-progress afk)]" > "$SP/ghq/0.json"
+  echo "[]" > "$SP/ghq/1.json"
+  run bash -c "cd '$SP' && '$RALPH_SH'"
+  [ "$status" -eq 0 ]
+  ! grep -q 'gh issue edit' "$RALPH_LOG"
+}
+
 @test "a green AFK story is auto-merged and closed (not re-selected)" {
   echo "[$(story 7 ready afk)]" > "$SP/ghq/0.json"
   echo "[]" > "$SP/ghq/1.json"

--- a/test/fixtures/stories/invalid/missing-prio.json
+++ b/test/fixtures/stories/invalid/missing-prio.json
@@ -1,9 +1,0 @@
-{
-  "number": 54,
-  "title": "Story with no priority label",
-  "labels": [
-    { "name": "state:ready" },
-    { "name": "type:afk" }
-  ],
-  "body": "## What to build\n\nHas no prio:N label, so the FIFO ordering can't place it.\n\n## Acceptance Criteria\n\n- [ ] Something\n\nDepends on: None\n"
-}

--- a/test/fixtures/stories/invalid/two-prios.json
+++ b/test/fixtures/stories/invalid/two-prios.json
@@ -1,0 +1,11 @@
+{
+  "number": 55,
+  "title": "Story with two priority labels",
+  "labels": [
+    { "name": "state:ready" },
+    { "name": "type:afk" },
+    { "name": "prio:1" },
+    { "name": "prio:3" }
+  ],
+  "body": "## What to build\n\nHas two prio:N labels, which is ambiguous.\n\n## Acceptance Criteria\n\n- [ ] Something\n\nDepends on: None\n"
+}

--- a/test/unit/test_init.py
+++ b/test/unit/test_init.py
@@ -1,0 +1,145 @@
+"""Unit tests for superproject bootstrap (`ralph --init`).
+
+`ralph --init` idempotently creates the canonical GitHub label vocabulary
+(state:/type:/prio:/needs-human/ready-for-human) that ralph_story/ralph_select
+consume, and ensures the configured base branch exists. The deterministic seam is
+a pure command *plan* (the ordered git/gh commands); a thin runner executes it,
+and the CLI (`ralph --init`) detects live repo state, prints, and sets exit codes.
+Behavior is covered against mocked git/gh on PATH.
+"""
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+LIB_DIR = os.path.join(REPO_ROOT, "lib")
+FIXTURES = os.path.join(REPO_ROOT, "test", "fixtures")
+RALPH = os.path.join(REPO_ROOT, "bin", "ralph")
+
+sys.path.insert(0, LIB_DIR)
+import ralph_init  # noqa: E402
+import ralph_story  # noqa: E402
+import ralph_select  # noqa: E402
+
+
+def _flat(commands):
+    return [tok for cmd in commands for tok in cmd]
+
+
+class InitPlanLabels(unittest.TestCase):
+    def test_creates_every_label_the_engine_consumes(self):
+        # The canonical vocabulary must cover exactly what the story validator and
+        # selection engine key off, or issues cannot be authored/transitioned.
+        plan = ralph_init.init_plan(base="develop", base_exists=True)
+        created = {cmd[3] for cmd in plan if cmd[:3] == ["gh", "label", "create"]}
+        for state in ralph_story.STATES:
+            self.assertIn("state:" + state, created)
+        for type_ in ralph_story.TYPES:
+            self.assertIn("type:" + type_, created)
+        self.assertIn(ralph_story.BLOCKER_LABEL, created)          # ready-for-human
+        self.assertIn(ralph_select.NEEDS_HUMAN_LABEL, created)     # needs-human
+
+    def test_seeds_a_prio_starter_range(self):
+        plan = ralph_init.init_plan(base="develop", base_exists=True, prio_max=5)
+        created = {cmd[3] for cmd in plan if cmd[:3] == ["gh", "label", "create"]}
+        for n in range(6):
+            self.assertIn("prio:%d" % n, created)
+        self.assertNotIn("prio:6", created)
+
+    def test_labels_are_idempotent_via_force(self):
+        plan = ralph_init.init_plan(base="develop", base_exists=True)
+        for cmd in plan:
+            if cmd[:3] == ["gh", "label", "create"]:
+                self.assertIn("--force", cmd)
+
+
+class InitPlanBaseBranch(unittest.TestCase):
+    def test_creates_base_off_default_when_missing(self):
+        plan = ralph_init.init_plan(base="develop", base_exists=False,
+                                    default_branch="main")
+        push = next((c for c in plan if c[:2] == ["git", "push"]), None)
+        self.assertIsNotNone(push, "a missing base must be created")
+        self.assertIn("origin/main:refs/heads/develop", push)
+
+    def test_does_not_create_base_when_present(self):
+        plan = ralph_init.init_plan(base="develop", base_exists=True)
+        self.assertFalse(any(c[:1] == ["git"] for c in plan))
+
+    def test_refuses_to_fabricate_main(self):
+        # Ralph never touches main (ADR-0001); init must not conjure it either.
+        plan = ralph_init.init_plan(base="main", base_exists=False)
+        self.assertFalse(any(c[:1] == ["git"] for c in plan))
+        self.assertNotIn("main:refs/heads/main", _flat(plan))
+
+
+class InitCli(unittest.TestCase):
+    def _mockbin(self, tmp, base_exists=False, default_branch="main",
+                 gh_exit=0, git_exit=0):
+        log = os.path.join(tmp, "calls.log")
+        gh = ('#!/usr/bin/env bash\n'
+              'echo "gh $*" >> "$RALPH_LOG"\n'
+              'if [[ "$1 $2" == "repo view" ]]; then echo "%s"; fi\n'
+              'exit %d\n' % (default_branch, gh_exit))
+        git = ('#!/usr/bin/env bash\n'
+               'echo "git $*" >> "$RALPH_LOG"\n'
+               'if [[ "$1" == "ls-remote" ]]; then %s fi\n'
+               'exit %d\n'
+               % ('echo "sha\trefs/heads/develop";' if base_exists else ':;',
+                  git_exit))
+        for name, body in (("gh", gh), ("git", git)):
+            path = os.path.join(tmp, name)
+            with open(path, "w") as fh:
+                fh.write(body)
+            os.chmod(path, os.stat(path).st_mode | stat.S_IEXEC | stat.S_IXGRP)
+        return log
+
+    def _run(self, tmp, log, config):
+        env = dict(os.environ, PATH=tmp + os.pathsep + os.environ["PATH"],
+                   RALPH_LOG=log)
+        return subprocess.run([RALPH, "--init", config], cwd=tmp, env=env,
+                              stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+    def test_creates_labels_and_missing_base(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = self._mockbin(tmp, base_exists=False, default_branch="main")
+            config = os.path.join(FIXTURES, "config", "valid", "full.yml")  # base: develop
+            proc = self._run(tmp, log, config)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            with open(log) as fh:
+                calls = fh.read()
+            self.assertIn("gh label create state:in-progress", calls)
+            self.assertIn("gh label create type:hil", calls)
+            self.assertIn("gh label create needs-human", calls)
+            self.assertIn("origin/main:refs/heads/develop", calls)  # base created
+
+    def test_idempotent_when_base_present(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = self._mockbin(tmp, base_exists=True)
+            config = os.path.join(FIXTURES, "config", "valid", "full.yml")
+            proc = self._run(tmp, log, config)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            with open(log) as fh:
+                calls = fh.read()
+            self.assertIn("gh label create state:ready", calls)
+            self.assertNotIn("git push", calls)  # base already there
+
+    def test_bad_config_exits_two(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = self._mockbin(tmp)
+            config = os.path.join(FIXTURES, "config", "invalid", "missing-gating.yml")
+            proc = self._run(tmp, log, config)
+            self.assertEqual(proc.returncode, 2, proc.stdout)
+
+    def test_gh_label_failure_exits_one(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = self._mockbin(tmp, gh_exit=1)
+            config = os.path.join(FIXTURES, "config", "valid", "full.yml")
+            proc = self._run(tmp, log, config)
+            self.assertEqual(proc.returncode, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit/test_orchestrate.py
+++ b/test/unit/test_orchestrate.py
@@ -199,6 +199,28 @@ class OrchestrationTest(unittest.TestCase):
         self.assertEqual(proc.returncode, 0, proc.stdout)
         self.assertFalse(any("claude" in ln for ln in h.log_lines()), h.log_lines())
 
+    def test_start_moves_ready_story_to_in_progress(self):
+        # AC: a `start` action transitions the story state:ready -> state:in-progress
+        # before its first iteration, so checkpoint/partial/completion see the
+        # expected state (and the story resumes rather than re-starts next pass).
+        h = self.harness()
+        h.set_backlogs([story(7, "ready", "afk")], [])
+        proc = h.run()
+        self.assertEqual(proc.returncode, 0, proc.stdout)
+        log = h.log_lines()
+        self.assertTrue(
+            any("issue edit 7" in ln and "state:in-progress" in ln
+                and "state:ready" in ln for ln in log), log)
+
+    def test_resume_does_not_relabel_the_story(self):
+        # AC: `resume` is already state:in-progress; the tick must not re-label it.
+        h = self.harness()
+        h.set_backlogs([story(5, "in-progress", "afk")], [])
+        proc = h.run()
+        self.assertEqual(proc.returncode, 0, proc.stdout)
+        self.assertFalse(any("issue edit" in ln for ln in h.log_lines()),
+                         h.log_lines())
+
     def test_green_afk_story_is_auto_merged_and_closed(self):
         # AC: an iteration that emits the done-signal on a type:afk story is
         # promoted via --complete-afk (auto-merge into base + close), not

--- a/test/unit/test_select_story.py
+++ b/test/unit/test_select_story.py
@@ -85,6 +85,22 @@ class Ordering(unittest.TestCase):
         )
         self.assertEqual(act.number, 4)
 
+    def test_story_without_prio_sorts_behind_prioritized_ones(self):
+        # prio is optional: a no-prio story (prio=None -> +inf) loses to any
+        # story that carries a prio:N, regardless of issue number.
+        act = action_for(
+            story(1, state="ready", type_="afk", prio=None),  # lower number...
+            story(9, state="ready", type_="afk", prio=5),      # ...but this wins
+        )
+        self.assertEqual((act.kind, act.number), (ralph_select.START, 9))
+
+    def test_prioless_stories_fall_back_to_fifo_among_themselves(self):
+        act = action_for(
+            story(7, state="ready", type_="afk", prio=None),
+            story(4, state="ready", type_="afk", prio=None),
+        )
+        self.assertEqual(act.number, 4)
+
     def test_blocked_state_is_skipped(self):
         act = action_for(
             story(1, state="blocked", type_="afk", prio=1),

--- a/test/unit/test_validate_story.py
+++ b/test/unit/test_validate_story.py
@@ -91,8 +91,9 @@ class MalformedStoriesAreRejected(unittest.TestCase):
     def test_two_type_labels_are_rejected(self):
         self._assert_invalid_mentioning("two-types.json", "type")
 
-    def test_missing_prio_is_rejected(self):
-        self._assert_invalid_mentioning("missing-prio.json", "prio")
+    def test_two_prio_labels_are_rejected(self):
+        # prio is optional, but at most one: two prio:N labels are ambiguous.
+        self._assert_invalid_mentioning("two-prios.json", "prio")
 
     def test_missing_depends_on_is_rejected(self):
         self._assert_invalid_mentioning("missing-depends.json", "Depends on")
@@ -112,6 +113,28 @@ class LabelShapeIsFlexible(unittest.TestCase):
         result = ralph_story.validate_story(story)
         self.assertTrue(result.ok, result.errors)
         self.assertEqual(result.fields["prio"], 3)
+
+
+class PrioIsOptional(unittest.TestCase):
+    def _story(self, labels):
+        return {
+            "number": 1, "title": "s", "labels": labels,
+            "body": "## Acceptance Criteria\n- [ ] ok\n\nDepends on: None\n",
+        }
+
+    def test_no_prio_label_is_valid_with_none_prio(self):
+        # A story may omit prio:N; it validates and carries prio=None.
+        result = ralph_story.validate_story(
+            self._story([{"name": "state:ready"}, {"name": "type:afk"}]))
+        self.assertTrue(result.ok, result.errors)
+        self.assertIsNone(result.fields["prio"])
+
+    def test_non_numeric_prio_is_rejected(self):
+        result = ralph_story.validate_story(
+            self._story([{"name": "state:ready"}, {"name": "type:afk"},
+                         {"name": "prio:high"}]))
+        self.assertFalse(result.ok)
+        self.assertTrue(any("prio" in e for e in result.errors))
 
 
 class CliLintStory(unittest.TestCase):


### PR DESCRIPTION
A real superproject run got past the completion push (HEAD: fix) only to fail the label move:

  gh issue edit 17 --add-label state:awaiting-bench --remove-label state:in-progress
  error: 'state:in-progress' not found

Root causes, all three fixed here:

1. No repo bootstrap. The canonical Ralph label vocabulary was never created in the superproject, so every `gh issue edit --add/remove-label` fails with `not found`. Add `ralph --init` (lib/ralph_init.py): a pure command plan that idempotently `gh label create --force`s the canonical state:/type:/needs-human/ready-for-human labels + a prio:0..5 starter range, and creates the configured base branch off the default branch if missing (refusing to fabricate main, ADR-0001). Wired into bin/ralph and the README Getting Started (new step 4) + command table.

2. Missing state-machine `start` edge. Nothing ever moved a story state:ready -> state:in-progress: the iteration is forbidden from touching state, resume/handoff/completion all *assume* in-progress, and a green story's --remove-label state:in-progress had nothing to remove. bin/ralph.sh now moves a `start`ed story to in-progress before the iteration (begin_story); `resume` is left as-is. This also fixes partial-progress stories being re-`start`ed instead of `resume`d (a latent gap from the #13 completion wiring).

3. prio was mandatory noise. Ordering is (prio, issue#) ascending, but the validator required exactly one prio:N on every story even though issue number already gives deterministic FIFO. Make prio optional (0 or 1 label; >1 or non-numeric still rejected): no prio => None => sorts last (+inf), falling back to FIFO. select_next already handled None, so this is validator + docs. Amend ADR-0002; update CONTEXT/README/SKILL/AGENTS.

Tests: +18 (init plan+CLI, start/resume relabel, prio-optional validate + selection ordering). Full suite 215 green. Swapped the now-valid missing-prio fixture for a two-prios rejection fixture.